### PR TITLE
refactor: 도서 검색 페이지 성능 개선

### DIFF
--- a/src/pages/book/search/index.tsx
+++ b/src/pages/book/search/index.tsx
@@ -1,15 +1,19 @@
+import dynamic from 'next/dynamic';
 import { useEffect } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import tw from 'tailwind-styled-components';
 
-import InfinityScrollLists from '@/components/book/search/InfinityScrollLists';
-import BottomNav from '@/components/common/BottomNav';
 import Header from '@/components/common/Header';
 import SearchInput from '@/components/common/SearchInput';
 import {
   searchBookTitleAtom,
   searchInfinityScrollPositionAtom,
 } from '@/recoil/book';
+
+const InfinityScrollLists = dynamic(
+  () => import('@/components/book/search/InfinityScrollLists'),
+);
+const BottomNav = dynamic(() => import('@/components/common/BottomNav'));
 
 const BookSearchPage = () => {
   const [searchBookTitle, setSearchBookTitle] =


### PR DESCRIPTION
## 📌 이슈 번호

- close #465 

## 👩‍💻 작업 내용

- 이슈에 작업의 필요성을 작성해 두었습니다~
- 성능 개선 전 프로덕트 환경에서 라이트 하우스를 통해 성능 측정(`성능 점수: 89점, LCP: 2.1s`) 
  - Light House는 프로덕트 환경에서 측정 하는 것이 정확하다고 합니다~(프로덕트 환경 yarn build =>  yarn start)
  
![개선 전2](https://github.com/dugeun-dugeun-project/Attic-Bookstore/assets/60873508/66ef69f6-9962-4107-942c-94d8ae5d6be0)

- Dynamic import를 사용해 무한 스크롤 리스트, Bottom Nav Bar 컴포넌트 동적으로 import(`성능 점수: 95점, LCP: 1.5s`)

![다이나믹 임포트 사용1](https://github.com/dugeun-dugeun-project/Attic-Bookstore/assets/60873508/fbc48b6b-d153-4c70-87ed-7bb2c35e9f9e)

- prettynigh font를 사용하는 곳에서만 설정할 경우(`성능 점수: 99점, LCP: 0.9s`) 
  - next/font/google 같은 경우는 성능 저하에 문제가 되지 않았지만 next/font/local 같은 경우 `컴퓨터에 설치된 로컬 폰트 파일을 사용하므로, 크기가 크고 다운로드 시간이 더 걸릴 수 있다.` 이와 같은 이유로 인해 성능 저하에 문제가 되는 것 같습니다~

![pretty Night layout patten으로 수정](https://github.com/dugeun-dugeun-project/Attic-Bookstore/assets/60873508/0fe0400d-843f-49ac-bfd3-cb92ba568ba3)

- 결론 : 최적화 작업을 통해 성능 점수를 89점에서 99점으로 올렸으며 FCP, LCP 소요시간을 각각 37.5%, 57% 개선하였습니다!


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
