### PR TITLE
fix: 도서 검색 페이지 새로고침 시 렌더링 안되는 문제

### DIFF
--- a/src/pages/book/search/index.tsx
+++ b/src/pages/book/search/index.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import tw from 'tailwind-styled-components';
 
+import BottomNav from '@/components/common/BottomNav';
 import Header from '@/components/common/Header';
 import SearchInput from '@/components/common/SearchInput';
 import {
@@ -13,7 +14,6 @@ import {
 const InfinityScrollLists = dynamic(
   () => import('@/components/book/search/InfinityScrollLists'),
 );
-const BottomNav = dynamic(() => import('@/components/common/BottomNav'));
 
 const BookSearchPage = () => {
   const [searchBookTitle, setSearchBookTitle] =


### PR DESCRIPTION
## 📌 이슈 번호

- close #490 

## 👩‍💻 작업 내용

- 문제 상황

![error](https://github.com/darakbooks-project/darakbooks-FE/assets/60873508/6c864e67-0a65-4dc7-a7c0-0436ff253a78)

- 성능 최적화를 위해 설정한 Dynamic import(Bottom Nav Bar)를 제거하니 정상적으로 렌더링 됩니다~

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

- Dynamic import로 인해 해당 error가 왜 발생했는데 모르겠습니다. 아시는 분 있으면 공유부탁드립니다~
