### PR TITLE
Design/#494 update UI

### DIFF
--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -70,6 +70,7 @@ const BottomNav = () => {
                 src={`../images/bottomNavBar/${src}-${
                   isClicked ? 'on' : 'off'
                 }.svg`}
+                priority
               />
               <Text $isClick={isClicked ? 'click' : ''}>{text}</Text>
             </Button>

--- a/src/components/common/Modal/Confirm.tsx
+++ b/src/components/common/Modal/Confirm.tsx
@@ -19,7 +19,7 @@ export default function ConfirmModal({
 }: ConfirmModalProps) {
   return (
     <ModalWrapper isOpen={isOpen}>
-      <div className='absolute flex flex-col items-center w-[66%] max-w-2xl gap-8 p-6 transform -translate-x-1/2 -translate-y-1/2 bg-white shadow-lg top-1/2 left-1/2 rounded-2xl'>
+      <div className='absolute flex flex-col items-center w-[66%] max-w-lg gap-8 p-6 transform -translate-x-1/2 -translate-y-1/2 bg-white shadow-lg top-1/2 left-1/2 rounded-2xl'>
         <div className='text-sm text-center whitespace-pre-line'>{text}</div>
         <div className='flex gap-4'>
           <Button size='small' color='blue' onButtonClick={onClickConfirm}>


### PR DESCRIPTION
## 📌 이슈 번호

- close #494 

## 👩‍💻 작업 내용

- slow 3g 속도에서 메인 페이지 접근시 Bottom Nav Bar의 아이콘이 모두 render 되는데 7s가 걸리고 priority props를 설정하면 4s에 render 됩니다. 
- desktop에서 render 되는 Login Modal이 컨텐츠 영역을 벗어나는게 UI적으로 좋지 못해 수정하였습니다~

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
